### PR TITLE
Prevent channel hopping

### DIFF
--- a/chowder/chowder.py
+++ b/chowder/chowder.py
@@ -112,6 +112,9 @@ class Chowder(commands.Cog):
         if voice_channel and voice and voice.channel == voice_channel:
             return
         elif voice_channel and voice and voice.is_connected():
+            #If current voice channel has same amount of members do not switch
+            if len(voice.channel.members) == len(voice_channel.members):
+                return
             print(f"Moving from {voice.channel.name} to {voice_channel.name}")
             await voice.disconnect()
             voice = await voice_channel.connect()


### PR DESCRIPTION
Unclear if guild class initializes the voice_channel list in the same order each time it is created. If not max(voice channel.members) could return a different channel each time fomo is called if multiple channels have the same amount of members