### PR TITLE
Ignore deleted messages by bots

### DIFF
--- a/chowder/chowder.py
+++ b/chowder/chowder.py
@@ -131,7 +131,14 @@ class Chowder(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message_delete(self, message):
+        # If the message deleted is not in a tracked channel, ignore.
         if message.channel.id not in channels or message.author == self.bot.user:
+            return
+        # If the message deleted is one the bot posted, ignore.
+        if message.author == self.bot.user:
+            return
+        # If the message deleted is posted by another bot, ignore.
+        if message.author.bot:
             return
         name = get_name(message.author)
         await message.channel.send(f"Whoa {message.author.mention} why you deleting messages {name}? Sketch")


### PR DESCRIPTION
Bot accounts sometimes post messages that they
then delete. This bot commenting on such is aggressive,
so ignore when bot messages are deleted.

[1] https://discordpy.readthedocs.io/en/stable/api.html#discord.abc.User.bot