### PR TITLE
Fix CGR calculation

### DIFF
--- a/cgr/cgr.py
+++ b/cgr/cgr.py
@@ -61,7 +61,7 @@ class Cgr(commands.Cog):
             await self.update_ratings_helper(ctx, [winners[0]], r2, 1.0 + (0.2 * len(players)), "whosaidit")
             r2 = math.pow(10, winner_rating/400)
             self.update_ratings_helper(ctx, winners[1:], r2, 0.4, "whosaidit")
-            self.update_ratings_helper(ctx, [p for p in players not in winners], r2, 0, "whosaidit")
+            self.update_ratings_helper(ctx, [p for p in players if p not in winners], r2, 0, "whosaidit")
         else:
             await self.update_ratings_ai(ctx, players, False, "whosaidit", game_config["whosaidit"]["base_rating"])
 


### PR DESCRIPTION
```python
>>> winners = [1, 2]
>>> players = [1, 2, 3, 4]
>>> losers = [p for p in players if p not in winners]
>>> losers
[3, 4]
```